### PR TITLE
Fix SPI-transactions for the ESP8266

### DIFF
--- a/SdFat/src/SdSpiCard/SdSpi.h
+++ b/SdFat/src/SdSpiCard/SdSpi.h
@@ -156,7 +156,11 @@ class SdSpiLib {
    */
   void beginTransaction(uint8_t divisor) {
 #if ENABLE_SPI_TRANSACTIONS
+    #ifdef ESP8266
+    SPI.beginTransaction(SPISettings(ESP8266_CLOCK, MSBFIRST, SPI_MODE0));
+    #else
     SPI.beginTransaction(SPISettings());
+    #fi
 #else  // #if ENABLE_SPI_TRANSACTIONS
     SPI.setBitOrder(MSBFIRST);
     SPI.setDataMode(SPI_MODE0);
@@ -353,7 +357,11 @@ inline void SdSpi::begin(uint8_t chipSelectPin) {
 //------------------------------------------------------------------------------
 inline void SdSpi::beginTransaction(uint8_t divisor) {
 #if ENABLE_SPI_TRANSACTIONS
+  #ifdef ESP8266
+  SPI.beginTransaction(SPISettings(ESP8266_CLOCK, MSBFIRST, SPI_MODE0));
+  #else
   SPI.beginTransaction(SPISettings());
+  #fi
 #endif  // ENABLE_SPI_TRANSACTIONS
   uint8_t b = 2;
   uint8_t r = 0;

--- a/SdFat/src/SdSpiCard/SdSpi.h
+++ b/SdFat/src/SdSpiCard/SdSpi.h
@@ -160,7 +160,7 @@ class SdSpiLib {
     SPI.beginTransaction(SPISettings(ESP8266_CLOCK, MSBFIRST, SPI_MODE0));
     #else
     SPI.beginTransaction(SPISettings());
-    #fi
+    #endif
 #else  // #if ENABLE_SPI_TRANSACTIONS
     SPI.setBitOrder(MSBFIRST);
     SPI.setDataMode(SPI_MODE0);
@@ -361,7 +361,7 @@ inline void SdSpi::beginTransaction(uint8_t divisor) {
   SPI.beginTransaction(SPISettings(ESP8266_CLOCK, MSBFIRST, SPI_MODE0));
   #else
   SPI.beginTransaction(SPISettings());
-  #fi
+  #endif
 #endif  // ENABLE_SPI_TRANSACTIONS
   uint8_t b = 2;
   uint8_t r = 0;


### PR DESCRIPTION
The library fails to function without these changes on the ESP8266 if SPI-transactions are enabled.