### PR TITLE
fix FsBaseFile copy constructor

### DIFF
--- a/src/FsLib/FsFile.cpp
+++ b/src/FsLib/FsFile.cpp
@@ -25,7 +25,8 @@
 #include "FsLib.h"
 //------------------------------------------------------------------------------
 FsBaseFile::FsBaseFile(const FsBaseFile& from) {
-  close();
+  m_fFile = nullptr;
+  m_xFile = nullptr;
   if (from.m_fFile) {
     m_fFile = new (m_fileMem) FatFile;
     *m_fFile = *from.m_fFile;


### PR DESCRIPTION
Don't close() in the copy constructor. When the copy constructor is called, m_fFile and m_xFile can contain garbage. The problem causes the system to hang when a function wants to return an FsBaseFile.