### PR TITLE
Default for ARM and avoid "File" conflict with FS.h

### DIFF
--- a/src/SdFat.h
+++ b/src/SdFat.h
@@ -397,16 +397,22 @@ class SdFs : public SdBase<FsVolume> {
 /** Select type for SdFat. */
 typedef SdFat32 SdFat;
 /** Select type for File. */
+#if !defined(__has_include) || !__has_include(<FS.h>)
 typedef File32 File;
+#endif
 /** Select type for SdBaseFile. */
 typedef FatFile SdBaseFile;
 #elif SDFAT_FILE_TYPE == 2
 typedef SdExFat SdFat;
+#if !defined(__has_include) || !__has_include(<FS.h>)
 typedef ExFile File;
+#endif
 typedef ExFatFile SdBaseFile;
 #elif SDFAT_FILE_TYPE == 3
 typedef SdFs SdFat;
+#if !defined(__has_include) || !__has_include(<FS.h>)
 typedef FsFile File;
+#endif
 typedef FsBaseFile SdBaseFile;
 #else  // SDFAT_FILE_TYPE
 #error Invalid SDFAT_FILE_TYPE

--- a/src/SdFatConfig.h
+++ b/src/SdFatConfig.h
@@ -73,6 +73,9 @@
 #if defined(__AVR__) && FLASHEND < 0X8000
 // 32K AVR boards.
 #define SDFAT_FILE_TYPE 1
+#elif defined(__arm__)
+// ARM boards usually have plenty of memory
+#define SDFAT_FILE_TYPE 3
 #else  // defined(__AVR__) && FLASHEND < 0X8000
 // All other boards.
 #define SDFAT_FILE_TYPE 1


### PR DESCRIPTION
Very minor edits, just a default to support all features on ARM and defining "File" conflicts with the FS.h header that defines a generic File class.