### PR TITLE
Fix flaky SD read into PSRAM on Teensy 4.1

### DIFF
--- a/src/SdCard/SdioTeensy.cpp
+++ b/src/SdCard/SdioTeensy.cpp
@@ -299,7 +299,7 @@ static void gpioMux(uint8_t mode) {
 static void enableGPIO(bool enable) {
   const uint32_t CLOCK_MASK = IOMUXC_SW_PAD_CTL_PAD_PKE |
 #if defined(ARDUINO_TEENSY41)
-                              IOMUXC_SW_PAD_CTL_PAD_DSE(1) |
+                              IOMUXC_SW_PAD_CTL_PAD_DSE(7) |
 #else  // defined(ARDUINO_TEENSY41)
                               IOMUXC_SW_PAD_CTL_PAD_DSE(4) |  ///// WHG
 #endif  // defined(ARDUINO_TEENSY41)


### PR DESCRIPTION
Increase the drive strength to make the signal more robust against interference from the PSRAM access. The value of DSE is found by increasing it until the interference goes away then increasing it once more. I tested using the test case posted here: https://forum.pjrc.com/threads/65851-Problem-reading-from-SD-card-directly-into-PSRAM . The test case fails quickly with DSE at 5 or less and passes reliably with DSE at 6 or 7.