### PR TITLE
support filesystem with only 1 fat

### DIFF
--- a/src/FatLib/FatPartition.cpp
+++ b/src/FatLib/FatPartition.cpp
@@ -431,10 +431,11 @@ bool FatPartition::init(FsBlockDevice* dev, uint8_t part, uint32_t volStart) {
     goto fail;
   }
   bpb = reinterpret_cast<BpbFat32_t*>(pbs->bpb);
-  if (bpb->fatCount != 2 || getLe16(bpb->bytesPerSector) != m_bytesPerSector) {
+  if ( !(bpb->fatCount == 1 || bpb->fatCount == 2) || getLe16(bpb->bytesPerSector) != m_bytesPerSector) {
     DBG_FAIL_MACRO;
     goto fail;
   }
+  m_fatCount = bpb->fatCount;
   m_sectorsPerCluster = bpb->sectorsPerCluster;
   m_clusterSectorMask = m_sectorsPerCluster - 1;
   // determine shift that is same as multiply by m_sectorsPerCluster
@@ -456,7 +457,7 @@ bool FatPartition::init(FsBlockDevice* dev, uint8_t part, uint32_t volStart) {
   m_rootDirEntryCount = getLe16(bpb->rootDirEntryCount);
 
   // directory start for FAT16 dataStart for FAT32
-  m_rootDirStart = m_fatStartSector + 2 * m_sectorsPerFat;
+  m_rootDirStart = m_fatStartSector + m_fatCount * m_sectorsPerFat;
   // data start for FAT16 and FAT32
   m_dataStartSector = m_rootDirStart +
     ((FS_DIR_SIZE*m_rootDirEntryCount + m_bytesPerSector - 1)/m_bytesPerSector);

--- a/src/FatLib/FatPartition.h
+++ b/src/FatLib/FatPartition.h
@@ -184,11 +184,12 @@ class FatPartition {
   static const uint16_t m_bytesPerSector = 1 << m_bytesPerSectorShift;
   static const uint16_t m_sectorMask = m_bytesPerSector - 1;
   //----------------------------------------------------------------------------
-  FsBlockDevice* m_blockDev;            // sector device
+  FsBlockDevice* m_blockDev;          // sector device
   uint8_t  m_sectorsPerCluster;       // Cluster size in sectors.
   uint8_t  m_clusterSectorMask;       // Mask to extract sector of cluster.
   uint8_t  m_sectorsPerClusterShift;  // Cluster count to sector count shift.
   uint8_t  m_fatType = 0;             // Volume type (12, 16, OR 32).
+  uint8_t  m_fatCount;                // Number of FAT (1 or 2)
   uint16_t m_rootDirEntryCount;       // Number of entries in FAT16 root dir.
   uint32_t m_allocSearchStart;        // Start cluster for alloc search.
   uint32_t m_sectorsPerFat;           // FAT size in sectors
@@ -240,7 +241,9 @@ class FatPartition {
 #if USE_SEPARATE_FAT_CACHE
   FsCache m_fatCache;
   uint8_t* fatCachePrepare(uint32_t sector, uint8_t options) {
-    options |= FsCache::CACHE_STATUS_MIRROR_FAT;
+    if ( m_fatCount == 2) {
+      options |= FsCache::CACHE_STATUS_MIRROR_FAT;
+    }
     return m_fatCache.prepare(sector, options);
   }
   bool cacheSync() {
@@ -248,7 +251,9 @@ class FatPartition {
   }
 #else  // USE_SEPARATE_FAT_CACHE
   uint8_t* fatCachePrepare(uint32_t sector, uint8_t options) {
-    options |= FsCache::CACHE_STATUS_MIRROR_FAT;
+    if ( m_fatCount == 2) {
+      options |= FsCache::CACHE_STATUS_MIRROR_FAT;
+    }
     return dataCachePrepare(sector, options);
   }
   bool cacheSync() {


### PR DESCRIPTION
same as https://github.com/greiman/SdFat/pull/404, but for beta repo

**What this PR does**
This PR add support for filesystem created with only 1 FAT. 

**Why it is needed**
Although FAT count is almost always 2, there is still cases where filesystem only has 1. Such as those with FAT12 on 2,4,8 MB SPI Flash. Especially with filesystem created by other platforms (micropython/circuitpython) that use [elm-chan fatfs](http://elm-chan.org/fsw/ff/doc/mkfs.html) which by default only generate 1 fat.

Some background: Thanks to your excellent work, Adafruit has been using SdFat to manage spi flash [Adafruit_SPIFlash](https://github.com/adafruit/Adafruit_SPIFlash). Back then v2 is still work in progress, and we are kind of too happy with v1 to upgrade until now :) . We are migrating to SdFat v2 and hopefully could contribute to testing/adding more support for FAT12 in the future.

@ladyada 